### PR TITLE
Feature/update circuit instance

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -12,10 +12,10 @@ let
   
   nixpkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
 
-  beta-rust = 
+  stable-rust = 
     (nixpkgs.rustChannelOf 
-      { date = "2018-10-24"; 
-        channel = "beta"; 
+      { date = "2018-12-06"; 
+        channel = "stable";
       }
     );
 
@@ -70,11 +70,11 @@ in
   stdenv.mkDerivation {
     name = "rust-env";
     buildInputs = [
-      beta-rust.rust 
-      beta-rust.rls-preview
-      beta-rust.rustfmt-preview
-      beta-rust.rust-analysis
-      beta-rust.clippy-preview
+      stable-rust.rust 
+      stable-rust.rls-preview
+      stable-rust.rustfmt-preview
+      stable-rust.rust-analysis
+      stable-rust.clippy-preview
 
       rustracer carnix 
     ];
@@ -82,7 +82,7 @@ in
     # Set Environment Variables
     RUST_BACKTRACE = 1;
     RUST_RACER_PATH = "${rustracer}/bin/racer";
-    RUST_SRC_PATH = "${beta-rust.rust-src}/lib/rustlib/src/rust/src/";
-    RUST_STD_DOCS_PATH = "${beta-rust.rust-docs}";
-    RUST_STD_PATH = "${beta-rust.rust-std}";
+    RUST_SRC_PATH = "${stable-rust.rust-src}/lib/rustlib/src/rust/src/";
+    RUST_STD_DOCS_PATH = "${stable-rust.rust-docs}";
+    RUST_STD_PATH = "${stable-rust.rust-std}";
   }

--- a/shell.nix
+++ b/shell.nix
@@ -1,44 +1,3 @@
-# let
-# in
-# 	with nixpkgs;
-# 	let
-# 		nightlyBuildRustPlatform = recurseIntoAttrs 
-# 				(makeRustPlatform 
-# 					(
-# 						{
-# 							rustc = nixpkgs.latest.rustChannels.nightly.rust;
-# 								# {
-# 								# 	date = "2018-09-08";
-# 								# 	hash = "1p0xkpfk66jq0iladqfrhqk1zc1jr9n2v2lqyf7jjbrmqx2ja65i";
-# 								# }; 
-# 							cargo = nixpkgs.latest.rustChannels.nightly.cargo;
-# 						}
-# 					)
-# 				);
-
-# 		racer = nightlyBuildRustPlatform.buildRustPackage rec {
-# 			name = "racer-${version}";
-# 			version = "v2.1.5";
-
-# 			src = fetchFromGitHub {
-# 				owner = "racer-rust";
-# 				repo = "racer";
-# 				rev = "${version}";
-# 				sha256 = "0dn4qck8yxkafpd4lx06x5vg23q3ssi47n4b3778p15g27m6gkdl";
-# 			};
-
-# 			doCheck = false;
-
-# 			cargoSha256 = "1qsjs3wq61njczqwcvj1gy3m55cmb37k4jgvpk2j5w64nba7mdx9";
-
-# 			meta = with stdenv.lib; {
-# 				description = "Rust Auto-Complete-er. A utility intended to provide Rust code completion for editors and IDEs.";
-# 				homepage = https://github.com/racer-rust/racer;
-# 				license = licenses.unlicense;
-# 				maintainers = [ maintainers.tailhook ];
-# 				platforms = platforms.all;
-# 			};
-# 		};
 let
   moz_overlay = import ((import <nixpkgs> {}).fetchFromGitHub 
     { owner = "mozilla";
@@ -52,24 +11,78 @@ let
     });
   
   nixpkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
+
+  beta-rust = 
+    (nixpkgs.rustChannelOf 
+      { date = "2018-10-24"; 
+        channel = "beta"; 
+      }
+    );
+
+	nightly-rust = 
+		(nixpkgs.rustChannelOf 
+			{ date = "2018-11-08";
+				channel = "nightly"; 
+			}
+		);
+
+  nightlyBuildRustPlatform = with nixpkgs; recurseIntoAttrs 
+  		(makeRustPlatform 
+  			(
+  				{
+  					rustc = nightly-rust.rustc;
+            cargo = nightly-rust.cargo;
+          }
+  			)
+  		);
+  
+  tarpaulin = with nixpkgs; nightlyBuildRustPlatform.buildRustPackage rec {
+  	name = "tarpaulin-${version}";
+  	version = "0.6.10";
+  
+  	src = fetchFromGitHub {
+  		owner = "xd009642";
+  		repo = "tarpaulin";
+  		rev = "${version}";
+  		sha256 = "1jw4jlrgv5an53q3idamkybv8i29426hmmf7x8kvr8lzbfcpsjc1";
+  	};
+  	
+  	buildInputs = [ nixpkgs.openssl nixpkgs.zlib ];
+
+    nativeBuildInputs = [ nixpkgs.pkgconfig nixpkgs.cmake nightly-rust.rust-std ];
+
+    RUSTFLAGS="--cfg procmacro2_semver_exempt";
+
+  	doCheck = false;
+  
+  	cargoSha256 = "0r0r633l07dnkbj77358asp6180d0y6psqfnrq2l5pkdshb0gb0w";
+  
+  	meta = with stdenv.lib; {
+  		description = "A code coverage tool for Rust projects";
+  		homepage = https://github.com/xd009642/tarpaulin;
+  		license = licenses.mit;
+  		maintainers = [ maintainers.tailhook ];
+  		platforms = platforms.all;
+  	};
+  };
 in
   with nixpkgs;
   stdenv.mkDerivation {
     name = "rust-env";
     buildInputs = [
-      # nixpkgs.latest.rustChannels.beta.rust
-      (nixpkgs.rustChannelOf { date = "2018-10-24"; channel = "beta"; }).rust
+      beta-rust.rust 
+      beta-rust.rls-preview
+      beta-rust.rustfmt-preview
+      beta-rust.rust-analysis
+      beta-rust.clippy-preview
 
-      rustfmt ctags rustracer rustPlatform.rustcSrc carnix 
-      rustup
-
-      vscode
-
-      liburcu openssl gnome3.gcr krb5 icu zlib
-      gnome3.gnome-keyring gnome3.libsecret desktop-file-utils xorg.xprop
-
+      rustracer carnix 
     ];
 
     # Set Environment Variables
     RUST_BACKTRACE = 1;
+    RUST_RACER_PATH = "${rustracer}/bin/racer";
+    RUST_SRC_PATH = "${beta-rust.rust-src}/lib/rustlib/src/rust/src/";
+    RUST_STD_DOCS_PATH = "${beta-rust.rust-docs}";
+    RUST_STD_PATH = "${beta-rust.rust-std}";
   }

--- a/src/field/mod.rs
+++ b/src/field/mod.rs
@@ -148,7 +148,8 @@ where
                     T::one()
                 }
             })
-        }).collect()
+        })
+        .collect()
 }
 
 /// The core reason we need a function like this is to let us cast
@@ -403,7 +404,8 @@ where
         .map(|(x, a)| {
             let (_, m, _) = ext_euc_alg(x, *a);
             m * x
-        }).zip(rems)
+        })
+        .zip(rems)
         .map(|(a, b)| a * *b)
         .fold(T::zero(), |acc, x| acc + x)
 }
@@ -516,7 +518,8 @@ where
                 .zip(powers(ri))
                 .map(|(&a, r)| a * r)
                 .fold(T::zero(), |acc, x| acc + x)
-        }).collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>()
 }
 
 /// Inverse Discrete Fourier Transformation
@@ -533,7 +536,8 @@ where
                 .map(|(&a, r)| a * r)
                 .fold(T::zero(), |acc, x| acc + x)
                 * T::from(seq.len()).mul_inv()
-        }).collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>()
 }
 
 #[cfg(test)]
@@ -615,7 +619,8 @@ mod tests {
         let result = vec![
             6, 86, 169, 189, 203, 131, 237, 118, 115, 91, 248, 177, 8, 48, 34, 136, 177, 203, 125,
             57, 237, 81, 9, 30, 122,
-        ].into_iter()
+        ]
+        .into_iter()
         .map(Z251::from)
         .collect::<Vec<_>>();
 

--- a/src/groth16/circuit/ast.rs
+++ b/src/groth16/circuit/ast.rs
@@ -78,8 +78,7 @@ where
                 }
             }
             _ => None,
-        })
-        .collect::<Vec<_>>()
+        }).collect::<Vec<_>>()
 }
 
 pub fn expressions<F>(code: &str) -> Result<Vec<Expression<F>>, ParseErr>
@@ -247,8 +246,7 @@ where
                         _ => (),
                     }
                     (t, depth)
-                })
-                .take_while(|&(_, d)| d != 0)
+                }).take_while(|&(_, d)| d != 0)
                 .map(|(t, _)| t)
                 .collect::<Vec<_>>()
                 .into()

--- a/src/groth16/circuit/ast.rs
+++ b/src/groth16/circuit/ast.rs
@@ -78,7 +78,8 @@ where
                 }
             }
             _ => None,
-        }).collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>()
 }
 
 pub fn expressions<F>(code: &str) -> Result<Vec<Expression<F>>, ParseErr>
@@ -246,7 +247,8 @@ where
                         _ => (),
                     }
                     (t, depth)
-                }).take_while(|&(_, d)| d != 0)
+                })
+                .take_while(|&(_, d)| d != 0)
                 .map(|(t, _)| t)
                 .collect::<Vec<_>>()
                 .into()

--- a/src/groth16/circuit/builder/mod.rs
+++ b/src/groth16/circuit/builder/mod.rs
@@ -3,7 +3,7 @@ use itertools::EitherOrBoth::{Both, Left, Right};
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::fmt;
-use std::ops::{BitXor, Shl, Shr, Rem};
+use std::ops::{BitXor, Rem, Shl, Shr};
 
 extern crate itertools;
 use itertools::Itertools;
@@ -13,7 +13,8 @@ mod tests;
 
 mod types;
 pub use self::types::{
-    Binary, BinaryInput, CanConvert, ValidateBalance, ValidateOrder, Word64, Word8, PairedInputWires
+    Binary, BinaryInput, CanConvert, PairedInputWires, ValidateBalance, ValidateOrder, Word64,
+    Word8,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -264,14 +265,13 @@ where
         N: Sized + From<u8> + Rem<Output = N> + Shr<Output = N> + Eq + Copy,
     {
         word.into_iter().enumerate().for_each(|(i, &t)| {
-            if input.shr(N::from(i as u8)) % N::from(2) == N::from(0) { 
+            if input.shr(N::from(i as u8)) % N::from(2) == N::from(0) {
                 self.set_value(t, T::zero());
             } else {
                 self.set_value(t, T::one());
             }
         });
     }
-
 
     ////////////////////////////////////////////////////////////////////////////////
     ///////////////////// Set and create new Wire Functions ////////////////////////

--- a/src/groth16/circuit/builder/mod.rs
+++ b/src/groth16/circuit/builder/mod.rs
@@ -33,7 +33,7 @@ pub struct SubCircuitConnections<T> {
     output: WireId,
 }
 
-#[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Default, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct WireId(usize);
 
 impl fmt::Debug for WireId {

--- a/src/groth16/circuit/builder/mod.rs
+++ b/src/groth16/circuit/builder/mod.rs
@@ -12,8 +12,8 @@ mod tests;
 
 mod types;
 pub use self::types::{
-    Binary, BinaryInput, CanConvert, PairedInputWires, ValidateBalance, ValidateOrder, Word64,
-    Word8, BinaryWire
+    Binary, BinaryInput, BinaryWire, CanConvert, PairedInputWires, ValidateBalance, ValidateOrder,
+    Word64, Word8,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -266,8 +266,8 @@ where
     where
         Z: IntoIterator<Item = &'a BinaryWire> + BinaryInput + CanConvert<'a, Number = N>,
     {
-        word.pair_bits(input).for_each(|(&wire, binary)| 
-            match binary {
+        word.pair_bits(input)
+            .for_each(|(&wire, binary)| match binary {
                 Binary::Zero => self.set_value(wire.into(), T::zero()),
                 Binary::One => self.set_value(wire.into(), T::one()),
             });
@@ -441,7 +441,10 @@ where
     ///////////////////////////////// Flatten Wires ////////////////////////////////
     ////////////////////////////////////////////////////////////////////////////////
 
-    pub fn bit_check<'a>(&mut self, input: impl IntoIterator<Item = &'a BinaryWire>) -> Vec<BinaryWire> {
+    pub fn bit_check<'a>(
+        &mut self,
+        input: impl IntoIterator<Item = &'a BinaryWire>,
+    ) -> Vec<BinaryWire> {
         input
             .into_iter()
             .map(|&x| self.new_bit_checker(x))
@@ -492,8 +495,7 @@ where
         &mut self,
         left_inputs: Vec<(T, WireId)>,
         right_inputs: Vec<(T, WireId)>,
-    ) -> WireId 
-    {
+    ) -> WireId {
         use self::ConnectionType::{Left, Output, Right};
 
         let sub_circuit_id = self.next_sub_circuit_id;
@@ -600,7 +602,13 @@ where
     where
         Z: IntoIterator<Item = &'a BinaryWire> + BinaryInput + CanConvert<'a, Number = N>,
     {
-        let iter = word.into_iter().map(|&x| if self.evaluate(x) == T::one() {Binary::One} else {Binary::Zero});
+        let iter = word.into_iter().map(|&x| {
+            if self.evaluate(x) == T::one() {
+                Binary::One
+            } else {
+                Binary::Zero
+            }
+        });
         Z::bits_to_num(iter)
     }
 
@@ -735,7 +743,11 @@ where
     pub fn new_or(&mut self, lhs: BinaryWire, rhs: BinaryWire) -> BinaryWire {
         let lhs_and_rhs = self.new_and(lhs, rhs);
         let one = T::one();
-        let lhs_inputs = vec![(-one, lhs_and_rhs.into()), (one, lhs.into()), (one, rhs.into())];
+        let lhs_inputs = vec![
+            (-one, lhs_and_rhs.into()),
+            (one, lhs.into()),
+            (one, rhs.into()),
+        ];
         let rhs_inputs = vec![(one, self.unity_wire())];
 
         BinaryWire::from(self.new_sub_circuit(lhs_inputs, rhs_inputs))
@@ -802,7 +814,12 @@ where
     }
 
     /// Requires that all left and right inputs in array are either 0 or 1
-    pub fn bitwise_op<F>(&mut self, left: &[BinaryWire], right: &[BinaryWire], mut gate: F) -> Vec<BinaryWire>
+    pub fn bitwise_op<F>(
+        &mut self,
+        left: &[BinaryWire],
+        right: &[BinaryWire],
+        mut gate: F,
+    ) -> Vec<BinaryWire>
     where
         F: FnMut(&mut Self, BinaryWire, BinaryWire) -> BinaryWire,
     {

--- a/src/groth16/circuit/builder/tests.rs
+++ b/src/groth16/circuit/builder/tests.rs
@@ -42,7 +42,7 @@ fn bit_checker_test() {
 fn bit_check_stream() {
     let mut circuit = Circuit::<Z251>::new();
     let wrd64 = circuit.new_word64();
-    circuit.set_word64(&wrd64, 25);
+    circuit.set_from_num(&wrd64, 25);
     let check = circuit.bit_check(&wrd64);
     check
         .into_iter()
@@ -191,10 +191,10 @@ fn greater_than_u8_u64_all_combinations() {
         (0..u64::max_value()).step((u64::max_value() / 29) as usize)
     ) {
         circuit.reset();
-        circuit.set_word64(&l_wire_u64, l_num);
-        circuit.set_word64(&r_wire_u64, r_num);
-        circuit.set_word8(&l_wire_u8, (l_num % 255) as u8);
-        circuit.set_word8(&r_wire_u8, (r_num % 255) as u8);
+        circuit.set_from_num(&l_wire_u64, l_num);
+        circuit.set_from_num(&r_wire_u64, r_num);
+        circuit.set_from_num(&l_wire_u8, (l_num % 255) as u8);
+        circuit.set_from_num(&r_wire_u8, (r_num % 255) as u8);
         // println!("this was tried: ({}, {})", l_num, r_num);
         if l_num > r_num {
             assert!(circuit.evaluate(u64_u64_cmp) == Z251::from(1));
@@ -317,8 +317,8 @@ fn evaluate_to_num_check() {
     let mut circuit = Circuit::<Z251>::new();
     let wrd8 = circuit.new_word8();
     let wrd64 = circuit.new_word64();
-    circuit.set_word8(&wrd8, 56);
-    circuit.set_word64(&wrd64, 110956);
+    circuit.set_from_num(&wrd8, 56);
+    circuit.set_from_num(&wrd64, 110956);
     assert_eq!(circuit.evaluate_to_num(&wrd8), 56);
     assert_eq!(circuit.evaluate_to_num(&wrd64), 110956);
 }
@@ -359,7 +359,7 @@ fn const_word8_sanity_check() {
 fn word64_set_eval() {
     let mut circuit = Circuit::<Z251>::new();
     let u64_input = circuit.new_word64();
-    circuit.set_word64(&u64_input, 1);
+    circuit.set_from_num(&u64_input, 1);
     assert_eq!(circuit.evaluate_to_num::<_, u64>(&u64_input), 1);
 }
 
@@ -367,7 +367,7 @@ fn word64_set_eval() {
 fn set_word8_sanity_check() {
     let mut circuit = Circuit::<Z251>::new();
     let u8_input = circuit.new_word8();
-    circuit.set_word8(&u8_input, 0b0000_0100);
+    circuit.set_from_num(&u8_input, 0b0000_0100);
     assert_eq!(circuit.evaluate(u8_input[0]), Z251::zero());
     assert_eq!(circuit.evaluate(u8_input[1]), Z251::zero());
     assert_eq!(circuit.evaluate(u8_input[2]), Z251::one());
@@ -383,7 +383,7 @@ fn set_word8_sanity_check() {
 fn set_word64_sanity_check() {
     let mut circuit = Circuit::<Z251>::new();
     let w64 = circuit.new_word64();
-    circuit.set_word64(&w64, 0b0100_1011_0100_1111);
+    circuit.set_from_num(&w64, 0b0100_1011_0100_1111);
     assert_eq!(circuit.evaluate(w64[0][0]), Z251::one());
     assert_eq!(circuit.evaluate(w64[0][1]), Z251::one());
     assert_eq!(circuit.evaluate(w64[0][2]), Z251::one());
@@ -450,7 +450,7 @@ fn u64_fan_in_single_test() {
     let mut elems: [Word64; 5] = [Word64::default(); 5];
     input.iter().enumerate().for_each(|(i, &num)| {
         let wrd64 = circuit.new_word64();
-        circuit.set_word64(&wrd64, num);
+        circuit.set_from_num(&wrd64, num);
         elems[i] = wrd64;
     });
 
@@ -996,8 +996,8 @@ quickcheck! {
 
         let left_word = circuit.new_word64();
         let right_word = circuit.new_word64();
-        circuit.set_word64(&left_word, left);
-        circuit.set_word64(&right_word, right);
+        circuit.set_from_num(&left_word, left);
+        circuit.set_from_num(&right_word, right);
 
         let complete_circuit = circuit.u64_bitwise_op(&left_word,
                     &types::rotate_word64_left(right_word, 1), Circuit::new_xor);
@@ -1011,8 +1011,8 @@ quickcheck! {
 
         let left_word = circuit.new_word64();
         let right_word = circuit.new_word64();
-        circuit.set_word64(&left_word, left);
-        circuit.set_word64(&right_word, right);
+        circuit.set_from_num(&left_word, left);
+        circuit.set_from_num(&right_word, right);
 
         let complete_circuit = circuit.u64_bitwise_op(&left_word, &right_word, Circuit::new_xor);
 
@@ -1044,7 +1044,7 @@ quickcheck! {
     fn word8_prop(num: u8) -> bool {
         let mut circuit = Circuit::<Z251>::new();
         let u8_input = circuit.new_word8();
-        circuit.set_word8(&u8_input, num);
+        circuit.set_from_num(&u8_input, num);
         circuit.evaluate_to_num::<_, u8>(&u8_input) == num
     }
 
@@ -1054,7 +1054,7 @@ quickcheck! {
     fn word64_prop(num: u64) -> bool {
         let mut circuit = Circuit::<Z251>::new();
         let u64_input = circuit.new_word64();
-        circuit.set_word64(&u64_input, num);
+        circuit.set_from_num(&u64_input, num);
         circuit.evaluate_to_num::<_, u64>(&u64_input) == num
     }
 

--- a/src/groth16/circuit/builder/tests.rs
+++ b/src/groth16/circuit/builder/tests.rs
@@ -1,8 +1,9 @@
 use super::super::super::Z251;
 use super::*;
 use field::FieldIdentity;
-use groth16::fr::FrLocal;
-use std::time::{Duration, Instant};
+// use groth16::fr::FrLocal; TODO: change some examples to use FrLocal
+use std::time::{Instant};
+use self::types::Binary::{One, Zero};
 
 extern crate quickcheck;
 use self::quickcheck::quickcheck;
@@ -51,127 +52,127 @@ fn bit_check_stream() {
 
 #[test]
 fn and_test() {
-    let logic_table = [(0, 0, 0), (0, 1, 0), (1, 0, 0), (1, 1, 1)];
+    let logic_table = [(Zero, Zero, Zero), (Zero, One, Zero), (One, Zero, Zero), (One, One, One)];
     let mut circuit = Circuit::<Z251>::new();
-    let l_wire = circuit.new_wire();
-    let r_wire = circuit.new_wire();
+    let l_wire = circuit.new_binary_wire();
+    let r_wire = circuit.new_binary_wire();
     let and = circuit.new_and(l_wire, r_wire);
 
     for (l, r, l_and_r) in logic_table.iter() {
         circuit.reset();
-        circuit.set_value(l_wire, Z251::from(*l));
-        circuit.set_value(r_wire, Z251::from(*r));
-        assert!(circuit.evaluate(and) == Z251::from(*l_and_r));
+        circuit.set_from_num(&l_wire, *l);
+        circuit.set_from_num(&r_wire, *r);
+        assert!(circuit.evaluate_to_num(&and) == *l_and_r);
     }
 }
 
 #[test]
 fn not_test() {
-    let logic_table = [(0, 1), (1, 0)];
+    let logic_table = [(Zero, One), (One, Zero)];
     let mut circuit = Circuit::<Z251>::new();
-    let wire = circuit.new_wire();
+    let wire = circuit.new_binary_wire();
     let not = circuit.new_not(wire);
 
     for (l, an) in logic_table.iter() {
         circuit.reset();
-        circuit.set_value(wire, Z251::from(*l));
-        assert!(circuit.evaluate(not) == Z251::from(*an));
+        circuit.set_from_num(&wire, *l);
+        assert!(circuit.evaluate_to_num(&not) == *an);
     }
 }
 
 #[test]
 fn or_test() {
-    let logic_table = [(0, 0, 0), (0, 1, 1), (1, 0, 1), (1, 1, 1)];
+    let logic_table = [(Zero, Zero, Zero), (Zero, One, One), (One, Zero, One), (One, One, One)];
     let mut circuit = Circuit::<Z251>::new();
-    let l_wire = circuit.new_wire();
-    let r_wire = circuit.new_wire();
+    let l_wire = circuit.new_binary_wire();
+    let r_wire = circuit.new_binary_wire();
     let or = circuit.new_or(l_wire, r_wire);
 
     for (l, r, l_or_r) in logic_table.iter() {
         circuit.reset();
-        circuit.set_value(l_wire, Z251::from(*l));
-        circuit.set_value(r_wire, Z251::from(*r));
-        assert!(circuit.evaluate(or) == Z251::from(*l_or_r));
+        circuit.set_from_num(&l_wire, *l);
+        circuit.set_from_num(&r_wire, *r);
+        assert!(circuit.evaluate_to_num(&or) == *l_or_r);
     }
 }
 
 #[test]
 fn nor_test() {
-    let logic_table = [(0, 0, 1), (0, 1, 0), (1, 0, 0), (1, 1, 0)];
+    let logic_table = [(Zero, Zero, One), (Zero, One, Zero), (One, Zero, Zero), (One, One, Zero)];
     let mut circuit = Circuit::<Z251>::new();
-    let l_wire = circuit.new_wire();
-    let r_wire = circuit.new_wire();
+    let l_wire = circuit.new_binary_wire();
+    let r_wire = circuit.new_binary_wire();
     let or = circuit.new_nor(l_wire, r_wire);
 
     for (l, r, l_or_r) in logic_table.iter() {
         circuit.reset();
-        circuit.set_value(l_wire, Z251::from(*l));
-        circuit.set_value(r_wire, Z251::from(*r));
-        assert!(circuit.evaluate(or) == Z251::from(*l_or_r));
+        circuit.set_from_num(&l_wire, *l);
+        circuit.set_from_num(&r_wire, *r);
+        assert!(circuit.evaluate_to_num(&or) == *l_or_r);
     }
 }
 
 #[test]
 fn xor_test() {
-    let logic_table = [(0, 0, 0), (0, 1, 1), (1, 0, 1), (1, 1, 0)];
+    let logic_table = [(Zero, Zero, Zero), (Zero, One, One), (One, Zero, One), (One, One, Zero)];
     let mut circuit = Circuit::<Z251>::new();
-    let l_wire = circuit.new_wire();
-    let r_wire = circuit.new_wire();
+    let l_wire = circuit.new_binary_wire();
+    let r_wire = circuit.new_binary_wire();
     let xor = circuit.new_xor(l_wire, r_wire);
 
     for (l, r, l_xor_r) in logic_table.iter() {
         circuit.reset();
-        circuit.set_value(l_wire, Z251::from(*l));
-        circuit.set_value(r_wire, Z251::from(*r));
-        assert!(circuit.evaluate(xor) == Z251::from(*l_xor_r));
+        circuit.set_from_num(&l_wire, *l);
+        circuit.set_from_num(&r_wire, *r);
+        assert!(circuit.evaluate_to_num(&xor) == *l_xor_r);
     }
 }
 
 #[test]
 fn xnor_test() {
-    let logic_table = [(0, 0, 1), (0, 1, 0), (1, 0, 0), (1, 1, 1)];
+    let logic_table = [(Zero, Zero, One), (Zero, One, Zero), (One, Zero, Zero), (One, One, One)];
     let mut circuit = Circuit::<Z251>::new();
-    let l_wire = circuit.new_wire();
-    let r_wire = circuit.new_wire();
+    let l_wire = circuit.new_binary_wire();
+    let r_wire = circuit.new_binary_wire();
     let xor = circuit.new_xnor(l_wire, r_wire);
 
     for (l, r, l_xor_r) in logic_table.iter() {
         circuit.reset();
-        circuit.set_value(l_wire, Z251::from(*l));
-        circuit.set_value(r_wire, Z251::from(*r));
-        assert!(circuit.evaluate(xor) == Z251::from(*l_xor_r));
+        circuit.set_from_num(&l_wire, *l);
+        circuit.set_from_num(&r_wire, *r);
+        assert!(circuit.evaluate_to_num(&xor) == *l_xor_r);
     }
 }
 
 #[test]
 fn new_less_than_test() {
-    let logic_table = [(0, 0, 0), (0, 1, 1), (1, 0, 0), (1, 1, 0)];
+    let logic_table = [(Zero, Zero, Zero), (Zero, One, One), (One, Zero, Zero), (One, One, Zero)];
     let mut circuit = Circuit::<Z251>::new();
-    let l_wire = circuit.new_wire();
-    let r_wire = circuit.new_wire();
+    let l_wire = circuit.new_binary_wire();
+    let r_wire = circuit.new_binary_wire();
     let less_than = circuit.new_less_than(l_wire, r_wire);
 
     for (l, r, l_less_r) in logic_table.iter() {
         circuit.reset();
-        circuit.set_value(l_wire, Z251::from(*l));
-        circuit.set_value(r_wire, Z251::from(*r));
-        assert!(circuit.evaluate(less_than) == Z251::from(*l_less_r));
+        circuit.set_from_num(&l_wire, *l);
+        circuit.set_from_num(&r_wire, *r);
+        assert!(circuit.evaluate_to_num(&less_than) == *l_less_r);
     }
 }
 
 #[test]
 fn new_greater_than_test() {
-    let logic_table = [(0, 0, 0), (0, 1, 0), (1, 0, 1), (1, 1, 0)];
+    let logic_table = [(Zero, Zero, Zero), (Zero, One, Zero), (One, Zero, One), (One, One, Zero)];
     let mut circuit = Circuit::<Z251>::new();
-    let l_wire = circuit.new_wire();
-    let r_wire = circuit.new_wire();
+    let l_wire = circuit.new_binary_wire();
+    let r_wire = circuit.new_binary_wire();
     let greater_than = circuit.new_greater_than(l_wire, r_wire);
 
     for (l, r, l_greater_r) in logic_table.iter() {
         circuit.reset();
-        circuit.set_value(l_wire, Z251::from(*l));
-        circuit.set_value(r_wire, Z251::from(*r));
-        assert!(circuit.evaluate(greater_than) == Z251::from(*l_greater_r));
+        circuit.set_from_num(&l_wire, *l);
+        circuit.set_from_num(&r_wire, *r);
+        assert!(circuit.evaluate_to_num(&greater_than) == *l_greater_r);
     }
 }
 
@@ -195,7 +196,6 @@ fn greater_than_u8_u64_all_combinations() {
         circuit.set_from_num(&r_wire_u64, r_num);
         circuit.set_from_num(&l_wire_u8, (l_num % 255) as u8);
         circuit.set_from_num(&r_wire_u8, (r_num % 255) as u8);
-        // println!("this was tried: ({}, {})", l_num, r_num);
         if l_num > r_num {
             assert!(circuit.evaluate(u64_u64_cmp) == Z251::from(1));
         } else {
@@ -212,22 +212,22 @@ fn greater_than_u8_u64_all_combinations() {
 #[test]
 fn fan_in_and_test() {
     let mut circuit = Circuit::<Z251>::new();
-    let mut wires = [WireId(0); 8];
+    let mut wires = [BinaryWire::default(); 8];
     for j in 0..8 {
-        wires[j] = circuit.new_wire();
+        wires[j] = circuit.new_binary_wire();
     }
 
     for i in 0..256 {
         circuit.reset();
         for j in 0..8 {
-            circuit.set_value(wires[j], Z251::from((i >> j) % 2));
+            circuit.set_from_num(&wires[j], Binary::from((i >> j) % 2));
         }
 
         let output = circuit.fan_in(&wires, Circuit::new_and);
         if i != 255 {
-            assert!(circuit.evaluate(output) == Z251::from(0));
+            assert!(circuit.evaluate_to_num(&output) == Zero);
         } else {
-            assert!(circuit.evaluate(output) == Z251::from(1));
+            assert!(circuit.evaluate_to_num(&output) == One);
         }
     }
 }
@@ -235,22 +235,22 @@ fn fan_in_and_test() {
 #[test]
 fn fan_in_or_test() {
     let mut circuit = Circuit::<Z251>::new();
-    let mut wires = [WireId(0); 8];
+    let mut wires = [BinaryWire::default(); 8];
     for j in 0..8 {
-        wires[j] = circuit.new_wire();
+        wires[j] = circuit.new_binary_wire();
     }
 
     for i in 0..256 {
         circuit.reset();
         for j in 0..8 {
-            circuit.set_value(wires[j], Z251::from((i >> j) % 2));
+            circuit.set_from_num(&wires[j], Binary::from((i >> j) % 2));
         }
 
         let output = circuit.fan_in(&wires, Circuit::new_or);
-        if i != 0 {
-            assert!(circuit.evaluate(output) == Z251::from(1));
+        if i != 255 {
+            assert!(circuit.evaluate_to_num(&output) == Zero);
         } else {
-            assert!(circuit.evaluate(output) == Z251::from(0));
+            assert!(circuit.evaluate_to_num(&output) == One);
         }
     }
 }
@@ -258,55 +258,55 @@ fn fan_in_or_test() {
 #[test]
 fn fan_in_xor_test() {
     let mut circuit = Circuit::<Z251>::new();
-    let mut wires = [WireId(0); 8];
+    let mut wires = [BinaryWire::default(); 8];
     for j in 0..8 {
-        wires[j] = circuit.new_wire();
+        wires[j] = circuit.new_binary_wire();
     }
 
     for i in 0..256 {
         circuit.reset();
         for j in 0..8 {
-            circuit.set_value(wires[j], Z251::from((i >> j) % 2));
+            circuit.set_from_num(&wires[j], Binary::from((i >> j) % 2));
         }
 
         let output = circuit.fan_in(&wires, Circuit::new_xor);
-        if i.count_ones() % 2 == 0 {
-            assert!(circuit.evaluate(output) == Z251::from(0));
+        if i != 255 {
+            assert!(circuit.evaluate_to_num(&output) == Zero);
         } else {
-            assert!(circuit.evaluate(output) == Z251::from(1));
+            assert!(circuit.evaluate_to_num(&output) == One);
         }
     }
 }
 
-#[test]
-fn bitwise_op_test() {
-    let mut circuit = Circuit::<Z251>::new();
-    let (l_wires, r_wires): (Vec<_>, Vec<_>) = (0..4)
-        .map(|_| (circuit.new_wire(), circuit.new_wire()))
-        .unzip();
+// #[test]
+// fn bitwise_op_test() {
+//     let mut circuit = Circuit::<Z251>::new();
+//     let (l_wires, r_wires): (Vec<_>, Vec<_>) = (0..4)
+//         .map(|_| (circuit.new_binary_wire(), circuit.new_binary_wire()))
+//         .unzip();
 
-    // let tmp = [|l: usize, r: usize| l ^ r, |l: usize, r: usize| l & r, |l, r| l | r];
-    // let tmp2 = [Circuit::<Z251>::new_xor, Circuit::new_and, Circuit::new_or];
+//     // let tmp = [|l: usize, r: usize| l ^ r, |l: usize, r: usize| l & r, |l, r| l | r];
+//     // let tmp2 = [Circuit::<Z251>::new_xor, Circuit::new_and, Circuit::new_or];
 
-    let out_wires = circuit.bitwise_op(&l_wires, &r_wires, Circuit::new_xor);
+//     let out_wires = circuit.bitwise_op(&l_wires, &r_wires, Circuit::new_xor);
 
-    (0..256).map(|n| (n >> 8, n % 16)).for_each(|(l, r)| {
-        circuit.reset();
-        for j in 0..4 {
-            circuit.set_value(l_wires[j], Z251::from((l >> j) % 2));
-            circuit.set_value(r_wires[j], Z251::from((r >> j) % 2));
-        }
-        assert_eq!(
-            out_wires
-                .iter()
-                .map(|&x| circuit.evaluate(x))
-                .map(|x| x.into())
-                .rev()
-                .fold(0, |acc, x: usize| (acc << 1) + x),
-            l ^ r
-        );
-    });
-}
+//     (0..256).map(|n| (n >> 8, n % 16)).for_each(|(l, r)| {
+//         circuit.reset();
+//         for j in 0..4 {
+//             circuit.set_from_num(&l_wires[j], Binary::from((l >> j) % 2));
+//             circuit.set_from_num(&r_wires[j], Binary::from((r >> j) % 2));
+//         }
+//         assert_eq!(
+//             out_wires
+//                 .iter()
+//                 .map(|x| circuit.evaluate_to_num(x))
+//                 .map(|x| x.into())
+//                 .rev()
+//                 .fold(0, |acc, x: u8| (acc << 1) + x),
+//             l ^ r
+//         );
+//     });
+// }
 
 ////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////// Word8/64 Tests ////////////////////////////////

--- a/src/groth16/circuit/builder/tests.rs
+++ b/src/groth16/circuit/builder/tests.rs
@@ -2,8 +2,8 @@ use super::super::super::Z251;
 use super::*;
 use field::FieldIdentity;
 // use groth16::fr::FrLocal; TODO: change some examples to use FrLocal
-use std::time::{Instant};
 use self::types::Binary::{One, Zero};
+use std::time::Instant;
 
 extern crate quickcheck;
 use self::quickcheck::quickcheck;
@@ -52,7 +52,12 @@ fn bit_check_stream() {
 
 #[test]
 fn and_test() {
-    let logic_table = [(Zero, Zero, Zero), (Zero, One, Zero), (One, Zero, Zero), (One, One, One)];
+    let logic_table = [
+        (Zero, Zero, Zero),
+        (Zero, One, Zero),
+        (One, Zero, Zero),
+        (One, One, One),
+    ];
     let mut circuit = Circuit::<Z251>::new();
     let l_wire = circuit.new_binary_wire();
     let r_wire = circuit.new_binary_wire();
@@ -82,7 +87,12 @@ fn not_test() {
 
 #[test]
 fn or_test() {
-    let logic_table = [(Zero, Zero, Zero), (Zero, One, One), (One, Zero, One), (One, One, One)];
+    let logic_table = [
+        (Zero, Zero, Zero),
+        (Zero, One, One),
+        (One, Zero, One),
+        (One, One, One),
+    ];
     let mut circuit = Circuit::<Z251>::new();
     let l_wire = circuit.new_binary_wire();
     let r_wire = circuit.new_binary_wire();
@@ -98,7 +108,12 @@ fn or_test() {
 
 #[test]
 fn nor_test() {
-    let logic_table = [(Zero, Zero, One), (Zero, One, Zero), (One, Zero, Zero), (One, One, Zero)];
+    let logic_table = [
+        (Zero, Zero, One),
+        (Zero, One, Zero),
+        (One, Zero, Zero),
+        (One, One, Zero),
+    ];
     let mut circuit = Circuit::<Z251>::new();
     let l_wire = circuit.new_binary_wire();
     let r_wire = circuit.new_binary_wire();
@@ -114,7 +129,12 @@ fn nor_test() {
 
 #[test]
 fn xor_test() {
-    let logic_table = [(Zero, Zero, Zero), (Zero, One, One), (One, Zero, One), (One, One, Zero)];
+    let logic_table = [
+        (Zero, Zero, Zero),
+        (Zero, One, One),
+        (One, Zero, One),
+        (One, One, Zero),
+    ];
     let mut circuit = Circuit::<Z251>::new();
     let l_wire = circuit.new_binary_wire();
     let r_wire = circuit.new_binary_wire();
@@ -130,7 +150,12 @@ fn xor_test() {
 
 #[test]
 fn xnor_test() {
-    let logic_table = [(Zero, Zero, One), (Zero, One, Zero), (One, Zero, Zero), (One, One, One)];
+    let logic_table = [
+        (Zero, Zero, One),
+        (Zero, One, Zero),
+        (One, Zero, Zero),
+        (One, One, One),
+    ];
     let mut circuit = Circuit::<Z251>::new();
     let l_wire = circuit.new_binary_wire();
     let r_wire = circuit.new_binary_wire();
@@ -146,7 +171,12 @@ fn xnor_test() {
 
 #[test]
 fn new_less_than_test() {
-    let logic_table = [(Zero, Zero, Zero), (Zero, One, One), (One, Zero, Zero), (One, One, Zero)];
+    let logic_table = [
+        (Zero, Zero, Zero),
+        (Zero, One, One),
+        (One, Zero, Zero),
+        (One, One, Zero),
+    ];
     let mut circuit = Circuit::<Z251>::new();
     let l_wire = circuit.new_binary_wire();
     let r_wire = circuit.new_binary_wire();
@@ -162,7 +192,12 @@ fn new_less_than_test() {
 
 #[test]
 fn new_greater_than_test() {
-    let logic_table = [(Zero, Zero, Zero), (Zero, One, Zero), (One, Zero, One), (One, One, Zero)];
+    let logic_table = [
+        (Zero, Zero, Zero),
+        (Zero, One, Zero),
+        (One, Zero, One),
+        (One, One, Zero),
+    ];
     let mut circuit = Circuit::<Z251>::new();
     let l_wire = circuit.new_binary_wire();
     let r_wire = circuit.new_binary_wire();

--- a/src/groth16/circuit/builder/types.rs
+++ b/src/groth16/circuit/builder/types.rs
@@ -9,13 +9,19 @@ use std::slice::{Iter, IterMut};
 
 pub trait BinaryInput {}
 
-pub trait CanConvert<T> {}
+pub trait CanConvert {
+    type Number;
+}
 
 #[derive(Clone, Copy, Debug)]
 pub enum Binary {
     Zero,
     One,
 }
+
+pub struct PairedInputWires<W, V>((W, V))
+where
+    W: CanConvert<Number = V>;
 
 pub struct ValidateOrder {
     pub is_x_within_range: WireId,
@@ -84,7 +90,9 @@ impl<'a> FromIterator<&'a WireId> for Word8 {
 }
 
 impl<'a> BinaryInput for &'a Word8 {}
-impl<'a> CanConvert<u8> for &'a Word8 {}
+impl<'a> CanConvert for &'a Word8 {
+    type Number = u8;
+}
 
 impl PartialEq for Word8 {
     fn eq(&self, other: &Word8) -> bool {
@@ -190,7 +198,9 @@ impl<'a> IntoIterator for &'a Word64 {
 }
 
 impl<'a> BinaryInput for &'a Word64 {}
-impl<'a> CanConvert<u64> for &'a Word64 {}
+impl<'a> CanConvert for &'a Word64 {
+    type Number = u64;
+}
 
 impl PartialEq for Word64 {
     fn eq(&self, other: &Word64) -> bool {

--- a/src/groth16/circuit/builder/types.rs
+++ b/src/groth16/circuit/builder/types.rs
@@ -364,9 +364,9 @@ mod tests {
         }
         fn flatten_to_word64_prop(rand: Vec<usize>) -> bool {
             let wrd64: Vec<WireId> = rand.into_iter().chain(0..64).take(64).map(|x| WireId(x)).collect();
-            let copy = wrd64.clone();
+            let wrd64_copy = wrd64.clone();
 
-            copy == flatten_word64([to_word64(wrd64.into_iter())].iter())
+            wrd64_copy == flatten_word64([to_word64(wrd64.into_iter())].iter())
         }
     }
 

--- a/src/groth16/circuit/builder/types.rs
+++ b/src/groth16/circuit/builder/types.rs
@@ -3,29 +3,90 @@ use super::*;
 extern crate itertools;
 use itertools::EitherOrBoth::{Both, Left, Right};
 use itertools::Itertools;
-use std::iter::FromIterator;
-use std::ops::{Index, IndexMut};
+use std::iter::{once, FromIterator, Once};
+use std::ops::{Index, IndexMut, Shr};
 use std::slice::{Iter, IterMut};
 
 pub trait BinaryInput {}
 
-pub trait CanConvert {
+pub trait CanConvert<'a> {
     type Number;
+    type PairedIter: Iterator<Item = (&'a BinaryWire, Binary)>;
+
+    fn pair_bits(&self, num: Self::Number) -> Self::PairedIter;
+
+    fn bits_to_num(bits: impl Iterator<Item = Binary>) -> Self::Number;
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Binary {
     Zero,
     One,
 }
 
-pub struct PairedInputWires<W, V>((W, V))
+impl Default for Binary {
+    fn default() -> Binary {
+        Binary::Zero
+    }
+}
+
+impl From<u8> for Binary {
+    fn from(num: u8) -> Self {
+        match num {
+            0 => Binary::Zero,
+            1 => Binary::One,
+            _ => panic!("Binary::From<u8> u8 was greater than 1"),
+        }
+    }
+}
+
+impl Into<u8> for Binary {
+    fn into(self) -> u8 {
+        match self {
+            Binary::Zero => 0,
+            Binary::One => 1,
+        }
+    }
+}
+
+impl Into<i8> for Binary {
+    fn into(self) -> i8 {
+        match self {
+            Binary::Zero => 0,
+            Binary::One => 1,
+        }
+    }
+}
+
+impl Into<u64> for Binary {
+    fn into(self) -> u64 {
+        match self {
+            Binary::Zero => 0,
+            Binary::One => 1,
+        }
+    }
+}
+
+impl Into<i64> for Binary {
+    fn into(self) -> i64 {
+        match self {
+            Binary::Zero => 0,
+            Binary::One => 1,
+        }
+    }
+}
+
+pub struct PairedInputWires<'a, W, V>
 where
-    W: CanConvert<Number = V>;
+    &'a W: CanConvert<'a, Number = V>,
+{
+    pub wire: &'a W,
+    pub value: V,
+}
 
 pub struct ValidateOrder {
-    pub is_x_within_range: WireId,
-    pub is_y_greater_than_c: WireId,
+    pub is_x_within_range: BinaryWire,
+    pub is_y_greater_than_c: BinaryWire,
     pub hash_x_y: [Word8; 32],
 }
 
@@ -33,10 +94,47 @@ pub struct ValidateBalance {
     pub x_hash: [Word8; 32],
     pub y_hash: [Word8; 32],
     pub z_hash: [Word8; 32],
-    pub is_z_eq_x_min_y: WireId,
+    pub is_z_eq_x_min_y: BinaryWire,
 }
 
-// TODO: Write a binary version of WireId
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct BinaryWire(usize);
+
+impl From<WireId> for BinaryWire {
+    fn from(wire: WireId) -> Self {
+        BinaryWire(wire.0)
+    }
+}
+
+impl Into<WireId> for BinaryWire {
+    fn into(self) -> WireId {
+        WireId(self.0)
+    }
+}
+
+impl<'a> BinaryInput for &'a BinaryWire {}
+impl<'a> CanConvert<'a> for &'a BinaryWire {
+    type Number = Binary;
+
+    type PairedIter = Once<(&'a BinaryWire, Binary)>;
+
+    fn pair_bits(&self, num: Self::Number) -> Self::PairedIter {
+        once((self, num))
+    }
+
+    fn bits_to_num(mut bits: impl Iterator<Item = Binary>) -> Self::Number {
+        bits.next().expect("Binary::bits_to_num: must have at least one input")
+    }
+}
+
+impl<'a> IntoIterator for &'a BinaryWire {
+    type Item = &'a BinaryWire;
+    type IntoIter = Once<&'a BinaryWire>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        once(&(self))
+    }
+}
 
 /// ## Usage Details:
 ///
@@ -47,51 +145,71 @@ pub struct ValidateBalance {
 ///       lets say you input the number 0x4B (ends in: 0100 1011) into the Word8
 ///       placeholder then it would be stored as: [1,1,0,1,0,0,1,0]
 ///
-#[derive(Clone, Copy, Debug)]
-pub struct Word8([WireId; 8]);
+#[derive(Debug, Clone, Copy)]
+pub struct Word8([BinaryWire; 8]);
 
 impl Word8 {
-    pub fn iter(&self) -> Iter<WireId> {
+    pub fn iter(&self) -> Iter<BinaryWire> {
         self.0.iter()
     }
 }
 
 impl<'a> IntoIterator for &'a Word8 {
-    type Item = &'a WireId;
-    type IntoIter = Iter<'a, WireId>;
+    type Item = &'a BinaryWire;
+    type IntoIter = Iter<'a, BinaryWire>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
     }
 }
 
-impl FromIterator<WireId> for Word8 {
-    fn from_iter<T: IntoIterator<Item = WireId>>(iter: T) -> Self {
+impl FromIterator<BinaryWire> for Word8 {
+    fn from_iter<T: IntoIterator<Item = BinaryWire>>(iter: T) -> Self {
         let mut arr: Word8 = Word8::default();
         (0..8).zip_longest(iter).for_each(|x| match x {
             Both(i, num) => arr[i] = num,
-            Left(_) => panic!("to_word8: Word8 cannot be constructed from less than 8 WireId"),
-            Right(_) => panic!("to_word8: Word8 cannot be constructed from more than 8 WireId"),
+            Left(_) => panic!("to_word8: Word8 cannot be constructed from less than 8 BinaryWire"),
+            Right(_) => panic!("to_word8: Word8 cannot be constructed from more than 8 BinaryWire"),
         });
         arr
     }
 }
 
-impl<'a> FromIterator<&'a WireId> for Word8 {
-    fn from_iter<T: IntoIterator<Item = &'a WireId>>(iter: T) -> Self {
+impl<'a> FromIterator<&'a BinaryWire> for Word8 {
+    fn from_iter<T: IntoIterator<Item = &'a BinaryWire>>(iter: T) -> Self {
         let mut arr: Word8 = Word8::default();
         (0..8).zip_longest(iter).for_each(|x| match x {
             Both(i, &num) => arr[i] = num,
-            Left(_) => panic!("to_word8: Word8 cannot be constructed from less than 8 WireId"),
-            Right(_) => panic!("to_word8: Word8 cannot be constructed from more than 8 WireId"),
+            Left(_) => panic!("to_word8: Word8 cannot be constructed from less than 8 BinaryWire"),
+            Right(_) => panic!("to_word8: Word8 cannot be constructed from more than 8 BinaryWire"),
         });
         arr
     }
 }
 
 impl<'a> BinaryInput for &'a Word8 {}
-impl<'a> CanConvert for &'a Word8 {
+impl<'a> CanConvert<'a> for &'a Word8 {
     type Number = u8;
+
+    type PairedIter = Box<Iterator<Item = (&'a BinaryWire, Binary)> + 'a>; 
+
+    fn pair_bits(&self, num: Self::Number) -> Self::PairedIter {
+        Box::new(self.into_iter().zip((0..8).map(move |i: u64|
+            match num.shr(i) % 2 {
+                0 => Binary::Zero,
+                _ => Binary::One,
+            })))
+    }
+
+    fn bits_to_num(bits: impl Iterator<Item = Binary>) -> Self::Number {
+        let num: u8 = 0;
+        bits.enumerate().fold(num, |acc, (i, b)| {
+                match b {
+                    Binary::One => acc ^ 1 << i,
+                    Binary::Zero => acc
+                }
+            })
+    }
 }
 
 impl PartialEq for Word8 {
@@ -103,41 +221,22 @@ impl Eq for Word8 {}
 
 impl Default for Word8 {
     fn default() -> Word8 {
-        Word8([WireId::default(); 8])
+        Word8([BinaryWire::default(); 8])
     }
 }
 
 impl Index<usize> for Word8 {
-    type Output = WireId;
+    type Output = BinaryWire;
 
-    fn index<'a>(&'a self, index: usize) -> &'a WireId {
+    fn index<'a>(&'a self, index: usize) -> &'a BinaryWire {
         &self.0[index]
     }
 }
 
 impl IndexMut<usize> for Word8 {
-    fn index_mut<'a>(&'a mut self, index: usize) -> &'a mut WireId {
+    fn index_mut<'a>(&'a mut self, index: usize) -> &'a mut BinaryWire {
         &mut self.0[index]
     }
-}
-
-/// This is a convenience function to create a `Word8` from exactly 8
-/// WireId any more or less will cause a panic
-pub fn to_word8(input: impl Iterator<Item = WireId>) -> Word8 {
-    let mut arr: Word8 = Word8::default();
-    (0..8).zip_longest(input).for_each(|x| match x {
-        Both(i, num) => arr[i] = num,
-        Left(_) => panic!("to_word8: Word8 cannot be constructed from less than 8 WireId"),
-        Right(_) => panic!("to_word8: Word8 cannot be constructed from more than 8 WireId"),
-    });
-    arr
-}
-
-// TODO: when you get the time refactor this to work just on
-// references. The reason you don't now is the way this function
-// interacts with to_word8 and the way you are using to_word8
-pub fn flatten_word8<'a>(input: impl IntoIterator<Item = &'a Word8>) -> Vec<WireId> {
-    input.into_iter().flat_map(|x| x.iter()).cloned().collect()
 }
 
 /// ## Usage Details:
@@ -152,9 +251,9 @@ pub fn flatten_word8<'a>(input: impl IntoIterator<Item = &'a Word8>) -> Vec<Wire
 ///
 /// `Word64` is really just a placeholder for a u64. It does not store a u64
 /// number, but can be assigned a u64 number before evaluation. Still this only
-/// associates the bits of a u64 number with the `WireId`s in the `Word64`.
+/// associates the bits of a u64 number with the `BinaryWire`s in the `Word64`.
 ///
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Word64([Word8; 8]);
 
 impl Word64 {
@@ -172,9 +271,9 @@ pub struct Word64Iter<'a> {
 }
 
 impl<'a> Iterator for Word64Iter<'a> {
-    type Item = &'a WireId;
+    type Item = &'a BinaryWire;
 
-    fn next(&mut self) -> Option<&'a WireId> {
+    fn next(&mut self) -> Option<&'a BinaryWire> {
         if self.count < 64 {
             let x = Some(&self.wrd64[self.count / 8][self.count % 8]);
             self.count += 1;
@@ -186,7 +285,7 @@ impl<'a> Iterator for Word64Iter<'a> {
 }
 
 impl<'a> IntoIterator for &'a Word64 {
-    type Item = &'a WireId;
+    type Item = &'a BinaryWire;
     type IntoIter = Word64Iter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -198,8 +297,29 @@ impl<'a> IntoIterator for &'a Word64 {
 }
 
 impl<'a> BinaryInput for &'a Word64 {}
-impl<'a> CanConvert for &'a Word64 {
+impl<'a> CanConvert<'a> for &'a Word64 {
     type Number = u64;
+
+    type PairedIter = Box<Iterator<Item = (&'a BinaryWire, Binary)> + 'a>; 
+
+    fn pair_bits(&self, num: Self::Number) -> Self::PairedIter {
+        Box::new(self.into_iter().zip((0..64).map(move |i: u64|
+            match num.shr(i) % 2 {
+                0 => Binary::Zero,
+                _ => Binary::One,
+            })))
+    }
+
+    fn bits_to_num(bits: impl Iterator<Item = Binary>) -> Self::Number {
+        let num: u64 = 0;
+        bits.enumerate().fold(num, |acc, (i, b)| {
+                match b {
+                    Binary::One => acc ^ 1 << i,
+                    Binary::Zero => acc
+                }
+            })
+    }
+
 }
 
 impl PartialEq for Word64 {
@@ -278,30 +398,6 @@ pub fn rotate_word64_right(input: Word64, by: usize) -> Word64 {
     wrd64
 }
 
-/// This is a convenience function to create a `Word64` from exactly
-/// 64 WireId any more or less will cause a panic
-pub fn to_word64(input: impl Iterator<Item = WireId>) -> Word64 {
-    let mut arr: Word64 = Word64::default();
-    input
-        .chunks(8)
-        .into_iter()
-        .map(|chunk| to_word8(chunk))
-        .zip_longest(0..8)
-        .for_each(|x| match x {
-            Both(num, i) => arr[i] = num,
-            Right(_) => panic!("to_word64: Word64 cannot be constructed from less than 64 WireId"),
-            Left(_) => panic!("to_word64: Word64 cannot be constructed from more than 64 WireId"),
-        });
-    arr
-}
-
-pub fn flatten_word64<'a>(input: impl Iterator<Item = &'a Word64>) -> Vec<WireId> {
-    input
-        .flat_map(|x| x.iter().flat_map(|i| i.iter()))
-        .cloned()
-        .collect()
-}
-
 pub const RC: [u64; 24] = [
     0x0000000000000001,
     0x0000000000008082,
@@ -356,34 +452,11 @@ mod tests {
 
     #[test]
     fn word8_iterator() {
-        let wrd8: Word8 = ((0..8).map(WireId)).collect();
+        let wrd8: Word8 = ((0..8).map(BinaryWire)).collect();
         let wrd8_2 = wrd8.into_iter().collect();
         assert_eq!(wrd8, wrd8_2);
     }
 
     quickcheck! {
-        fn rotate_inverse_prop(rotate_by: usize) -> bool {
-            let word64 = to_word64((0..64).map(WireId));
-            word64 == rotate_word64_right(rotate_word64_left(word64, rotate_by), rotate_by)
-        }
-        fn rotate_mod(by: usize) -> bool {
-            let word64 = to_word64((0..64).map(WireId));
-            rotate_word64_left(word64, by + 64) == rotate_word64_left(word64, by)
-                &&
-            rotate_word64_right(word64, by + 64) == rotate_word64_right(word64, by)
-        }
-        fn flatten_to_word64_prop(rand: Vec<usize>) -> bool {
-            let wrd64: Vec<WireId> = rand.into_iter().chain(0..64).take(64).map(|x| WireId(x)).collect();
-            let wrd64_copy = wrd64.clone();
-
-            wrd64_copy == flatten_word64([to_word64(wrd64.into_iter())].iter())
-        }
-    }
-
-    #[test]
-    fn rotate_single_test() {
-        let a_wrd64: Word64 = to_word64((0..64).map(WireId));
-        let b_wrd64: Word64 = to_word64((63..64).chain(0..63).map(WireId));
-        assert_eq!(b_wrd64, rotate_word64_left(a_wrd64, 1));
     }
 }

--- a/src/groth16/circuit/builder/types.rs
+++ b/src/groth16/circuit/builder/types.rs
@@ -123,7 +123,8 @@ impl<'a> CanConvert<'a> for &'a BinaryWire {
     }
 
     fn bits_to_num(mut bits: impl Iterator<Item = Binary>) -> Self::Number {
-        bits.next().expect("Binary::bits_to_num: must have at least one input")
+        bits.next()
+            .expect("Binary::bits_to_num: must have at least one input")
     }
 }
 
@@ -191,24 +192,24 @@ impl<'a> BinaryInput for &'a Word8 {}
 impl<'a> CanConvert<'a> for &'a Word8 {
     type Number = u8;
 
-    type PairedIter = Box<Iterator<Item = (&'a BinaryWire, Binary)> + 'a>; 
+    type PairedIter = Box<Iterator<Item = (&'a BinaryWire, Binary)> + 'a>;
 
     fn pair_bits(&self, num: Self::Number) -> Self::PairedIter {
-        Box::new(self.into_iter().zip((0..8).map(move |i: u64|
-            match num.shr(i) % 2 {
-                0 => Binary::Zero,
-                _ => Binary::One,
-            })))
+        Box::new(
+            self.into_iter()
+                .zip((0..8).map(move |i: u64| match num.shr(i) % 2 {
+                    0 => Binary::Zero,
+                    _ => Binary::One,
+                })),
+        )
     }
 
     fn bits_to_num(bits: impl Iterator<Item = Binary>) -> Self::Number {
         let num: u8 = 0;
-        bits.enumerate().fold(num, |acc, (i, b)| {
-                match b {
-                    Binary::One => acc ^ 1 << i,
-                    Binary::Zero => acc
-                }
-            })
+        bits.enumerate().fold(num, |acc, (i, b)| match b {
+            Binary::One => acc ^ 1 << i,
+            Binary::Zero => acc,
+        })
     }
 }
 
@@ -300,26 +301,25 @@ impl<'a> BinaryInput for &'a Word64 {}
 impl<'a> CanConvert<'a> for &'a Word64 {
     type Number = u64;
 
-    type PairedIter = Box<Iterator<Item = (&'a BinaryWire, Binary)> + 'a>; 
+    type PairedIter = Box<Iterator<Item = (&'a BinaryWire, Binary)> + 'a>;
 
     fn pair_bits(&self, num: Self::Number) -> Self::PairedIter {
-        Box::new(self.into_iter().zip((0..64).map(move |i: u64|
-            match num.shr(i) % 2 {
-                0 => Binary::Zero,
-                _ => Binary::One,
-            })))
+        Box::new(
+            self.into_iter()
+                .zip((0..64).map(move |i: u64| match num.shr(i) % 2 {
+                    0 => Binary::Zero,
+                    _ => Binary::One,
+                })),
+        )
     }
 
     fn bits_to_num(bits: impl Iterator<Item = Binary>) -> Self::Number {
         let num: u64 = 0;
-        bits.enumerate().fold(num, |acc, (i, b)| {
-                match b {
-                    Binary::One => acc ^ 1 << i,
-                    Binary::Zero => acc
-                }
-            })
+        bits.enumerate().fold(num, |acc, (i, b)| match b {
+            Binary::One => acc ^ 1 << i,
+            Binary::Zero => acc,
+        })
     }
-
 }
 
 impl PartialEq for Word64 {
@@ -457,6 +457,5 @@ mod tests {
         assert_eq!(wrd8, wrd8_2);
     }
 
-    quickcheck! {
-    }
+    quickcheck! {}
 }

--- a/src/groth16/circuit/dummy_rep.rs
+++ b/src/groth16/circuit/dummy_rep.rs
@@ -79,7 +79,8 @@ impl<'a> From<&'a str> for DummyRep<Z251> {
                         .clone()
                         .into_iter()
                         .chain(temp_vars.clone().into_iter()),
-                ).position(|s| s == first)
+                )
+                .position(|s| s == first)
                 .unwrap()
                 + 1;
 
@@ -103,7 +104,8 @@ impl<'a> From<&'a str> for DummyRep<Z251> {
                                 .clone()
                                 .into_iter()
                                 .chain(temp_vars.clone().into_iter()),
-                        ).position(|s| s == l)
+                        )
+                        .position(|s| s == l)
                         .unwrap()
                         + 1;
 
@@ -123,7 +125,8 @@ impl<'a> From<&'a str> for DummyRep<Z251> {
                             .clone()
                             .into_iter()
                             .chain(temp_vars.clone().into_iter()),
-                    ).position(|s| s == r)
+                    )
+                    .position(|s| s == r)
                     .unwrap()
                     + 1;
 

--- a/src/groth16/circuit/dummy_rep.rs
+++ b/src/groth16/circuit/dummy_rep.rs
@@ -79,9 +79,9 @@ impl<'a> From<&'a str> for DummyRep<Z251> {
                         .clone()
                         .into_iter()
                         .chain(temp_vars.clone().into_iter()),
-                )
-                .position(|s| s == first)
-                .unwrap() + 1;
+                ).position(|s| s == first)
+                .unwrap()
+                + 1;
 
             w[pos].push(((n + 1).into(), 1.into()));
             symbols.next();
@@ -103,9 +103,9 @@ impl<'a> From<&'a str> for DummyRep<Z251> {
                                 .clone()
                                 .into_iter()
                                 .chain(temp_vars.clone().into_iter()),
-                        )
-                        .position(|s| s == l)
-                        .unwrap() + 1;
+                        ).position(|s| s == l)
+                        .unwrap()
+                        + 1;
 
                     u[pos].push(((n + 1).into(), 1.into()));
                 }
@@ -123,9 +123,9 @@ impl<'a> From<&'a str> for DummyRep<Z251> {
                             .clone()
                             .into_iter()
                             .chain(temp_vars.clone().into_iter()),
-                    )
-                    .position(|s| s == r)
-                    .unwrap() + 1;
+                    ).position(|s| s == r)
+                    .unwrap()
+                    + 1;
 
                 v[pos].push(((n + 1).into(), 1.into()));
             }

--- a/src/groth16/circuit/mod.rs
+++ b/src/groth16/circuit/mod.rs
@@ -101,12 +101,12 @@ use self::dummy_rep::DummyRep;
 /// let mut circuit = Circuit::<FrLocal>::new();
 /// let input_x = circuit.new_binary_wire();
 /// let word_u8 = circuit.new_word8();
-/// let input_y = circuit.new_binary_wire();
+/// let input_y = circuit.new_word64();
 ///
 /// create_input_struct!(InputWires {
 ///     input_x: (BinaryWire, Binary),
 ///     word_u8: (Word8, u8),
-///     input_y: (BinaryWire, Binary),
+///     input_y: (Word64, u64),
 /// });
 ///
 /// // This is a convenience function to create a new struct of the
@@ -114,7 +114,7 @@ use self::dummy_rep::DummyRep;
 /// let ex1: InputWires = InputWires::new(
 ///       (&input_x, One)
 ///     , (&word_u8, 5)
-///     , (&input_y, Zero)
+///     , (&input_y, 104986)
 ///     );
 /// 
 /// // These are here to show you what the resulting struct actually
@@ -125,7 +125,7 @@ use self::dummy_rep::DummyRep;
 /// assert_eq!(ex1.word_u8.value, 5);
 /// assert_eq!(ex1.word_u8.wire, &word_u8);
 ///
-/// assert_eq!(ex1.input_y.value, Zero);
+/// assert_eq!(ex1.input_y.value, 104986);
 /// assert_eq!(ex1.input_y.wire, &input_y);
 /// # }
 /// ```

--- a/src/groth16/circuit/mod.rs
+++ b/src/groth16/circuit/mod.rs
@@ -73,9 +73,9 @@ pub mod dummy_rep;
 
 use self::ast::TokenList;
 use self::ast::{Expression, ParseErr};
+use self::builder::{Circuit, WireId};
 use self::builder::{ConnectionType, SubCircuitId};
 use self::dummy_rep::DummyRep;
-use self::builder::{Circuit, WireId};
 
 #[macro_export]
 macro_rules! replace_expr {
@@ -100,12 +100,12 @@ macro_rules! create_input_struct {
             ) -> Self {
                 $name {
                     $label_1: PairedInputWires {
-                        wire: $label_1.0, 
+                        wire: $label_1.0,
                         value: $label_1.1,
                     },
                     $(
                         $label: PairedInputWires {
-                            wire: $label.0, 
+                            wire: $label.0,
                             value: $label.1,
                         },
                     )*
@@ -122,7 +122,7 @@ macro_rules! create_input_struct {
             }
         }
 
-        impl<'a, T> SetCircuitInputs<T> for $name<'a> 
+        impl<'a, T> SetCircuitInputs<T> for $name<'a>
         where
             T: Field
         {
@@ -173,7 +173,7 @@ where
     F: Fn(SubCircuitId) -> T,
     V: IntoIterator<Item = &'a W>,
     I: IntoIterator<Item = &'a W> + SetCircuitInputs<T>,
-    W: Into<WireId> + Clone
+    W: Into<WireId> + Clone,
 {
     pub fn new(
         circuit: Circuit<T>,
@@ -197,7 +197,11 @@ where
         // Since we only can get`WireId`s from verification_wires `V`
         // and we need to check if a given `WireId` is one of the
         // verification_wires we turn it into a HashSet.
-        let verification_wire_set: HashSet<WireId> = verification_wires.into_iter().cloned().map(|x| x.into()).collect();
+        let verification_wire_set: HashSet<WireId> = verification_wires
+            .into_iter()
+            .cloned()
+            .map(|x| x.into())
+            .collect();
 
         let (mut verification_ids, witness_ids) = circuit
             .wire_assignments() // map will all assigned WireId
@@ -749,7 +753,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use self::builder::{PairedInputWires, Word8, BinaryWire};
+    use self::builder::{BinaryWire, PairedInputWires, Word8};
     use super::super::super::field::z251::Z251;
     use super::dummy_rep::DummyRep;
     use super::*;

--- a/src/groth16/circuit/mod.rs
+++ b/src/groth16/circuit/mod.rs
@@ -68,7 +68,7 @@ use std::marker::PhantomData;
 use std::collections::hash_set::HashSet;
 
 mod ast;
-mod builder;
+pub mod builder;
 pub mod dummy_rep;
 
 use self::ast::TokenList;
@@ -79,7 +79,7 @@ use self::dummy_rep::DummyRep;
 // This exports flatten_word8 because builder is a private module, so
 // there is no other way to export it for lib.rs without making
 // builder public.
-pub use self::builder::{flatten_word8, BinaryInput, Circuit, WireId, Word64, Word8};
+use self::builder::{Circuit, WireId, Word8};
 
 pub trait SetCircuitInputs<T> 
 where
@@ -866,8 +866,8 @@ mod tests {
             type Input = (u8, u8);
 
             fn set_inputs(&self, circuit: &mut Circuit<Z251>, set: &Self::Input) {
-                circuit.set_word8(&self.left, set.0);
-                circuit.set_word8(&self.right, set.1);
+                circuit.set_from_num(self.left, set.0);
+                circuit.set_from_num(self.right, set.1);
             }
         }
 

--- a/src/groth16/coefficient_poly.rs
+++ b/src/groth16/coefficient_poly.rs
@@ -123,7 +123,8 @@ where
                 self_iter
                     .zip(rhs_iter)
                     .fold(T::from(0), |acc, (&a, &b)| acc + a * b)
-            }).collect::<Vec<_>>();
+            })
+            .collect::<Vec<_>>();
 
         CoefficientPoly { coeffs }
     }
@@ -349,7 +350,8 @@ mod tests {
                 Z251::from(28),
                 Z251::from(27),
                 Z251::from(18),
-            ].into()
+            ]
+            .into()
         );
 
         // Multiplication with overflow
@@ -363,7 +365,8 @@ mod tests {
                 Z251::from(242),
                 Z251::from(198),
                 Z251::from(18),
-            ].into()
+            ]
+            .into()
         );
     }
 

--- a/src/groth16/fr.rs
+++ b/src/groth16/fr.rs
@@ -274,7 +274,8 @@ mod tests {
     fn bn_encrypt_quad_test() {
         let root_rep = ASTParser::try_parse(
             &*::std::fs::read_to_string("test_programs/lispesque_quad.zk").unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let qap: QAP<CoefficientPoly<FrLocal>> = root_rep.into();
 
         for _ in 0..10 {
@@ -305,7 +306,8 @@ mod tests {
     fn bn_encrypt_cubic_test() {
         let root_rep = ASTParser::try_parse(
             &*::std::fs::read_to_string("test_programs/lispesque_cubic.zk").unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let qap: QAP<CoefficientPoly<FrLocal>> = root_rep.into();
 
         let trials = 10;

--- a/src/groth16/mod.rs
+++ b/src/groth16/mod.rs
@@ -151,7 +151,8 @@ where
         .zip(qap.v.as_slice().iter().zip(qap.w.as_slice().iter()))
         .map(|(ui, (vi, wi))| {
             ((beta * ui.evaluate(x) + alpha * vi.evaluate(x) + wi.evaluate(x)) / gamma).encrypt_g1()
-        }).take(qap.input + 1)
+        })
+        .take(qap.input + 1)
         .collect::<Vec<_>>();
     let sum_delta = qap
         .u
@@ -160,7 +161,8 @@ where
         .zip(qap.v.as_slice().iter().zip(qap.w.as_slice().iter()))
         .map(|(ui, (vi, wi))| {
             ((beta * ui.evaluate(x) + alpha * vi.evaluate(x) + wi.evaluate(x)) / delta).encrypt_g1()
-        }).skip(qap.input + 1)
+        })
+        .skip(qap.input + 1)
         .collect::<Vec<_>>();
     let xi_t = xi
         .as_slice()
@@ -482,9 +484,9 @@ mod tests {
                 [0, 0, 0],
                 [0, 0, 0],
             ]
-                .iter()
-                .map(|v| v.iter().map(|&c| c.into()).collect::<Vec<_>>().into())
-                .collect::<Vec<_>>(),
+            .iter()
+            .map(|v| v.iter().map(|&c| c.into()).collect::<Vec<_>>().into())
+            .collect::<Vec<_>>(),
             v: [
                 [0, 0, 0],
                 [0, 0, 0],
@@ -495,9 +497,9 @@ mod tests {
                 [248, 4, 250],
                 [1, 124, 126],
             ]
-                .iter()
-                .map(|v| v.iter().map(|&c| c.into()).collect::<Vec<_>>().into())
-                .collect::<Vec<_>>(),
+            .iter()
+            .map(|v| v.iter().map(|&c| c.into()).collect::<Vec<_>>().into())
+            .collect::<Vec<_>>(),
             w: [
                 [0, 0, 0],
                 [0, 0, 0],
@@ -508,9 +510,9 @@ mod tests {
                 [3, 123, 126],
                 [248, 4, 250],
             ]
-                .iter()
-                .map(|v| v.iter().map(|&c| c.into()).collect::<Vec<_>>().into())
-                .collect::<Vec<_>>(),
+            .iter()
+            .map(|v| v.iter().map(|&c| c.into()).collect::<Vec<_>>().into())
+            .collect::<Vec<_>>(),
             t: [245, 11, 245, 1]
                 .iter()
                 .map(|&c| c.into())
@@ -557,9 +559,9 @@ mod tests {
                 [0, 0, 0],
                 [0, 0, 0],
             ]
-                .iter()
-                .map(|v| v.iter().map(|&c| c.into()).collect::<Vec<_>>().into())
-                .collect::<Vec<_>>(),
+            .iter()
+            .map(|v| v.iter().map(|&c| c.into()).collect::<Vec<_>>().into())
+            .collect::<Vec<_>>(),
             v: [
                 [0, 0, 0],
                 [0, 0, 0],
@@ -570,9 +572,9 @@ mod tests {
                 [248, 4, 250],
                 [1, 124, 126],
             ]
-                .iter()
-                .map(|v| v.iter().map(|&c| c.into()).collect::<Vec<_>>().into())
-                .collect::<Vec<_>>(),
+            .iter()
+            .map(|v| v.iter().map(|&c| c.into()).collect::<Vec<_>>().into())
+            .collect::<Vec<_>>(),
             w: [
                 [0, 0, 0],
                 [0, 0, 0],
@@ -583,9 +585,9 @@ mod tests {
                 [3, 123, 126],
                 [248, 4, 250],
             ]
-                .iter()
-                .map(|v| v.iter().map(|&c| c.into()).collect::<Vec<_>>().into())
-                .collect::<Vec<_>>(),
+            .iter()
+            .map(|v| v.iter().map(|&c| c.into()).collect::<Vec<_>>().into())
+            .collect::<Vec<_>>(),
             t: [245, 11, 245, 1]
                 .iter()
                 .map(|&c| c.into())
@@ -760,7 +762,8 @@ mod tests {
         // Quadratic polynomial share
         let root_rep: DummyRep<Z251> = ASTParser::try_parse(
             &*::std::fs::read_to_string("test_programs/lispesque_quad.zk").unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let qap = root_rep.into();
 
         for _ in 0..1000 {
@@ -789,7 +792,8 @@ mod tests {
         // Cubic polynomial share
         let root_rep: DummyRep<Z251> = ASTParser::try_parse(
             &*::std::fs::read_to_string("test_programs/lispesque_cubic.zk").unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
         let qap = root_rep.into();
 
         for _ in 0..1000 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,7 +268,7 @@ mod tests {
         let y = circuit.new_binary_wire();
         let y_checker = circuit.new_bit_checker(y);
         let or = circuit.new_or(x, y);
-        
+
         create_input_struct!(InputWires {
             x: (BinaryWire, Binary),
             y: (BinaryWire, Binary)
@@ -349,10 +349,12 @@ mod tests {
         let (sigmag1, sigmag2) = groth16::setup(&qap);
         let proof = groth16::prove(&qap, (&sigmag1, &sigmag2), &weights);
 
-        assert_eq!(groth16::verify::<CoefficientPoly<FrLocal>, _, _, _, _>(
-            (sigmag1, sigmag2),
-            &[FrLocal::from(0)],
-            proof),
+        assert_eq!(
+            groth16::verify::<CoefficientPoly<FrLocal>, _, _, _, _>(
+                (sigmag1, sigmag2),
+                &[FrLocal::from(0)],
+                proof
+            ),
             false
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,8 @@ pub use groth16::circuit::dummy_rep::DummyRep;
 #[doc(hidden)]
 pub use groth16::circuit::{ASTParser, TryParse};
 #[doc(hidden)]
-pub use groth16::circuit::{Circuit, CircuitInstance, WireId};
+pub use groth16::circuit::builder::{Circuit, WireId};
+pub use groth16::circuit::{CircuitInstance};
 #[doc(hidden)]
 pub use groth16::coefficient_poly::CoefficientPoly;
 #[doc(hidden)]
@@ -147,7 +148,7 @@ mod tests {
     use super::field::z251::Z251;
     use super::groth16::Random;
     use super::*;
-    use groth16::circuit::{flatten_word8, Word8};
+    use groth16::circuit::builder::{Word8};
     use groth16::fr::{G1Local, G2Local};
 
     extern crate tiny_keccak;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,7 +271,7 @@ mod tests {
 
         create_input_struct!(InputWires {
             x: (BinaryWire, Binary),
-            y: (BinaryWire, Binary)
+            y: (BinaryWire, Binary),
         });
 
         let input = InputWires::new((&x, Binary::Zero), (&y, Binary::One));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,7 +303,7 @@ mod tests {
 
         create_input_struct!(Struct1 {
             l: (Word8, u8),
-            r: (Word8, u8)
+            r: (Word8, u8),
         });
 
         let input = Struct1::new((&left, 26), (&right, 11));
@@ -334,7 +334,7 @@ mod tests {
 
         create_input_struct!(Struct1 {
             l: (Word8, u8),
-            r: (Word8, u8)
+            r: (Word8, u8),
         });
 
         let input = Struct1::new((&left, 26), (&right, 11));


### PR DESCRIPTION
This is to make `CircuitInstance` generic enough to handle any type of structure containing `WireId`s.

I wanted to get some early feedback on this while I write more tests to ensure it functions as we expect. (Tests don't cause controversy)

The hope is to get feedback, make improvements and merge by Friday.

Note: Still missing Macro for ease of use.